### PR TITLE
Add average guess stat

### DIFF
--- a/game/package-lock.json
+++ b/game/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wordgame",
-	"version": "2.6.0",
+	"version": "2.6.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wordgame",
-			"version": "2.6.0",
+			"version": "2.6.1",
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^1.0.0-next.90",
 				"@sveltejs/adapter-static": "^2.0.3",

--- a/game/package.json
+++ b/game/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wordgame",
-	"version": "2.6.0",
+	"version": "2.6.1",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/game/src/routes/stats/StatsGraph.svelte
+++ b/game/src/routes/stats/StatsGraph.svelte
@@ -9,12 +9,21 @@
 
 	const { title, numberOfGames, stats }: IProps = $props();
 
+	const numberOfGuesses = [...Array(NUMBER_TRIES + 1).keys(), -1];
+
+	// Sum of games won per number of guesses.
+	// Losses count as +1 over the allowed max number of guesses.
+	const guessSum = numberOfGuesses.reduce((sum, winIndex) => {
+		const gamesWon = stats[winIndex] ?? 0;
+		const guessScore = (winIndex === -1 ? NUMBER_TRIES + 1 : winIndex) + numberOfGames;
+		return sum + guessScore * gamesWon;
+	}, 0);
+
 	const winPercentage = stats['played'] !== 0 ? (stats['wins'] / stats['played']) * 100 : 0;
+	const averageGuesses = stats['played'] !== 0 ? guessSum / stats['played'] : 0;
 	const maxHeight = 240;
 	const lineHeight = 2;
 	const maxBarHeight = `calc(${maxHeight}px - ${2 * lineHeight}em)`;
-
-	const numberOfGuesses = [...Array(NUMBER_TRIES + 1).keys(), -1];
 
 	function getAriaValueForBar(gamesWon: number): number {
 		const gamesPlayed = stats['played'];
@@ -39,6 +48,7 @@
 		{/snippet}
 		{@render stat({ title: 'Played', value: stats['played'] })}
 		{@render stat({ title: 'Won', value: `${+winPercentage.toFixed(2)}%` })}
+		{@render stat({ title: 'Avg Guess', value: +averageGuesses.toFixed(2) })}
 		{@render stat({ title: 'Streak', value: stats['streak'] })}
 		{@render stat({ title: 'Max Streak', value: stats['maxStreak'] })}
 	</div>


### PR DESCRIPTION
Adds a new stat tracking the average number of guesses needed to win the game.

It is computed by:

```
sum = 0
for each (key, value):
  sum = sum + key * value

avg = sum / total number of games played
```

Given classic mode and the following win distribution:
```
 {
  won in 1: 0,
  won in 2: 0,
  won in 3: 2,
  won in 4: 7,
  won in 5: 5,
  won in 6: 4,
  lost/7: 8
}
```

The average guess would be `5.35`