### PR TITLE
Use popover API for menu and simplify its styles

### DIFF
--- a/game/package-lock.json
+++ b/game/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wordgame",
-	"version": "2.6.1",
+	"version": "2.7.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wordgame",
-			"version": "2.6.1",
+			"version": "2.7.0",
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^1.0.0-next.90",
 				"@sveltejs/adapter-static": "^2.0.3",

--- a/game/package.json
+++ b/game/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wordgame",
-	"version": "2.6.1",
+	"version": "2.7.0",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/game/src/routes/MenuItem.svelte
+++ b/game/src/routes/MenuItem.svelte
@@ -6,22 +6,34 @@
 		activeDescendant: string | undefined;
 		children: Snippet;
 	}
+
 	let { id, activeDescendant, children }: IProps = $props();
 </script>
 
-<li {id} role="menuitem" class:focused={activeDescendant === id}>
+<li role="presentation" class="menu-item" class:focused={activeDescendant === id}>
 	{@render children()}
 </li>
 
 <style>
-	li[role='menuitem'] {
+	.menu-item {
 		padding: 0.5rem 4px;
 		border-radius: 4px;
 		text-align: start;
 	}
 
-	.focused,
-	li[role='menuitem']:hover {
+	.menu-item:hover {
+		background-color: var(--color-menu-hover);
+	}
+
+	.focused {
 		outline: 2px solid var(--color-focus-ring);
+	}
+
+	:global(.menu-item-command) {
+		display: flex;
+		flex-direction: row;
+		gap: 8px;
+		outline: none;
+		color: var(--color-text);
 	}
 </style>

--- a/game/src/routes/ThemeToggle.svelte
+++ b/game/src/routes/ThemeToggle.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
 	import type { Theme } from '$lib/types';
 	import { getContext } from 'svelte';
 	import MenuItem from './MenuItem.svelte';
-	import Icon from '$lib/components/Icon.svelte';
 
 	interface IProps {
 		activeDescendant: string | undefined;
@@ -51,11 +51,20 @@
 
 <li role="presentation">
 	<span id="theme-submenu">Theme</span>
-	<ul role="menu" aria-labelledby="theme-submenu">
+	<ul role="group" class="menu-list" aria-labelledby="theme-submenu">
 		{#each themes as [dataId, label, iconPath]}
 			{@const selected = currentTheme.theme === dataId}
 			<MenuItem id={dataId} {activeDescendant}>
-				<button data-theme={dataId} on:click={update} tabindex="-1" class:selected>
+				<button
+					id={dataId}
+					role="menuitemradio"
+					class="menu-item-command"
+					class:selected
+					aria-checked={selected}
+					data-theme={dataId}
+					on:click={update}
+					tabindex="-1"
+				>
 					<Icon path={selected ? `${iconPath}_enabled` : `${iconPath}_disabled`} />
 					{label}
 				</button>
@@ -67,7 +76,7 @@
 <style>
 	button {
 		width: 100%;
-		background: inherit;
+		background: unset;
 		color: inherit;
 		border: none;
 		padding: 0;

--- a/game/src/routes/colors.css
+++ b/game/src/routes/colors.css
@@ -5,6 +5,7 @@
 	--color-bg-0: #cad8e4;
 	--color-bg-1: #cedce8;
 	--color-menu-bg: #ffffff;
+	--color-menu-hover: hsla(0, 0%, 90%, 0.40);
 	--color-shadow: #00000080;
 	--color-theme-1: #ff3e00;
 	--color-theme-2: #4075a6;
@@ -27,6 +28,7 @@
 	--color-bg-0: hsl(208, 33%, 9%);
 	--color-bg-1: hsl(208, 36%, 11%);
 	--color-menu-bg: hsl(208, 20%, 22%);
+	--color-menu-hover: hsla(208, 20%, 32%, 0.40);
 	--color-shadow: #000000f0;
 	--color-theme-1: #ff3e00;
 	--color-theme-2: #4075a6;
@@ -49,6 +51,7 @@
 		--color-bg-0: hsl(208, 33%, 9%);
 		--color-bg-1: hsl(208, 36%, 11%);
 		--color-menu-bg: hsl(208, 20%, 22%);
+		--color-menu-hover: hsla(208, 20%, 32%, 0.40);
 		--color-shadow: #000000f0;
 		--color-theme-1: #ff3e00;
 		--color-theme-2: #4075a6;
@@ -71,6 +74,7 @@
 		--color-bg-0: #cad8e4;
 		--color-bg-1: #cedce8;
 		--color-menu-bg: #ffffff;
+		--color-menu-hover: hsla(0, 0%, 90%, 0.40);
 		--color-shadow: #00000080;
 		--color-theme-1: #ff3e00;
 		--color-theme-2: #4075a6;

--- a/game/src/routes/styles.css
+++ b/game/src/routes/styles.css
@@ -28,27 +28,6 @@ body {
 		linear-gradient(180deg, var(--color-bg-0) 0%, var(--color-bg-1) 15%);
 }
 
-ul[role="menu"] {
-	list-style: none;
-	padding: 0;
-	outline: none;
-}
-
-ul[role="menu"]:has(li[role='menuitem']:hover) li[role='menuitem'].focused:not(:hover) {
-	outline: none;
-}
-
-li[role='menuitem'] > * {
-	display: flex;
-	flex-direction: row;
-	gap: 8px;
-}
-
-li[role='menuitem'] a,
-li[role='menuitem'] button {
-	outline: none;
-}
-
 p {
 	line-height: 1.5;
 }

--- a/game/src/routes/styles.css
+++ b/game/src/routes/styles.css
@@ -60,10 +60,6 @@ button {
 	font-family: inherit;
 }
 
-button:focus:not(:focus-visible) {
-	outline: none;
-}
-
 .visually-hidden {
 	border: 0;
 	clip: rect(0 0 0 0);


### PR DESCRIPTION
* Fixes #64 
  * Uses [Popover API | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) to show/hide the menu
  * Only shows focus ring when navigating with the keyboard
  * Refactors and simplifies the code handling focus and navigation